### PR TITLE
web: fixed link to Facebook page

### DIFF
--- a/src/index
+++ b/src/index
@@ -32,7 +32,7 @@
       <a href="https://plus.google.com/108003112428040046828?prsrc=3" rel="publisher" style="text-decoration:none;">
         <strong><i class="fa fa-google-plus"></i></strong></a> &nbsp;
       <a href="https://twitter.com/FFmpeg"><strong><i class="fa fa-twitter"></i></strong></a> &nbsp;
-      <a href="https://www.facebook.com/ffmpeg.org"><strong><i class="fa fa-facebook"></i></strong></a>
+      <a href="https://www.facebook.com/ffmpeg"><strong><i class="fa fa-facebook"></i></strong></a>
     </span>
     News
   </h1>


### PR DESCRIPTION
The Facebook page settings have been changed. So, the page url has changed.